### PR TITLE
Fix the detection of empty .po files

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Smartcat-App
 
 {{$NEXT}}
 
+        - Fix the detection of empty .po files
+
 0.0.3  2020-07-20 22:40:42 UTC
         - Set up version of Smartcat::Client => 0.0.2
 

--- a/lib/Smartcat/App/Utils.pm
+++ b/lib/Smartcat/App/Utils.pm
@@ -93,20 +93,23 @@ sub save_file {
 
 sub are_po_files_empty {
     my $filepaths = shift;
-    my $res = 1;
+    my $empty = 1;
 
     for my $filepath (@$filepaths) {
-      open(my $fh, $filepath) or die "Can't read $filepath: $!\n";
-      binmode($fh);
-      while (my $line = <$fh>) {
-        $res = ($1 eq "") if $line =~ m/msgid "(.*)"/;
-        last if !$res;
-      }
-      close $fh;
-      last if !$res;
-    }
+        open(my $fh, $filepath) or die "Can't read $filepath: $!\n";
+        binmode($fh, ':utf8');
+        my $text = join('', <$fh>);
+        close $fh;
 
-    return $res;
+        # join multi-line entries
+        $text =~ s/"\n"//sg;
+
+        if ($text =~ m/msgid "[^"]/s) {
+            $empty = undef;
+            last;
+        }
+    }
+    return $empty;
 }
 
 


### PR DESCRIPTION
This commit implements a fix for detecting if .po files are not empty by taking into account units with multiline `msgid` values.