### PR TITLE
Be resilient to Windows-style line endings

### DIFF
--- a/lib/Smartcat/App/Utils.pm
+++ b/lib/Smartcat/App/Utils.pm
@@ -102,7 +102,7 @@ sub are_po_files_empty {
         close $fh;
 
         # join multi-line entries
-        $text =~ s/"\n"//sg;
+        $text =~ s/"\r?\n"//sg;
 
         if ($text =~ m/msgid "[^"]/s) {
             $empty = undef;


### PR DESCRIPTION
Smartcat produces .po files with CRLF line breaks which then can suffer from the issue fixed in 6d5ec06bc0af9697fd70f79bdd37165fbd6e201c. This commit makes it work for CRLF, too.