### PR TITLE
Use UTF-8 filenames at document creation time (follow-up for #22)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Smartcat-App
 
 {{$NEXT}}
+        - Bugfixes for UTF-8 filename support
 
 0.0.8  2021-03-26 17:17:54 UTC
         - Fix availability to export translated files via `pull` command

--- a/lib/Smartcat/App/ProjectApi.pm
+++ b/lib/Smartcat/App/ProjectApi.pm
@@ -1,6 +1,9 @@
 use strict;
 use warnings;
 
+use utf8;
+no utf8;
+
 package Smartcat::App::ProjectApi;
 
 use Smartcat::Client::ProjectApi;
@@ -109,12 +112,16 @@ sub upload_file {
       Smartcat::Client::Object::CreateDocumentPropertyModel->new(%args);
 
     $log->info("Uploading file '$path'...");
+    my $utf8_path = $path;
+    my $utf8_filename = $filename;
+    utf8::encode($utf8_path);
+    utf8::encode($utf8_filename);
     %args = (
         project_id     => $self->{rundata}->{project_id},
         document_model => $document,
         file           => {
-            path     => $path,
-            filename => $filename
+            path     => $utf8_path,
+            filename => $utf8_filename
         }
     );
     $args{disassemble_algorithm_name} =


### PR DESCRIPTION
This is a follow-up commit for 1fe37b512fdfaa6eea5ed0f07d0fb0d30a9cd722 — it turns out in the previous commit I handled only document updates, while document creation goes through a different module, and also requires UTF-8 encoded fields (document path and filename).